### PR TITLE
Added layer progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ A plugin that sends M117 (and optionally M73) commands to the printer to display
 Install manually using this URL:
 
     https://github.com/tpmullan/OctoPrint-DetailedProgress/archive/master.zip
+    
+## Dependencies for layer progress etc. [Optional] 
+
+If you also want to display layer progress, height progress or time to filament change, you will have to install the plugin [DisplayLayerProgress](https://plugins.octoprint.org/plugins/DisplayLayerProgress).
+Follow setup instructions for that plugin.
 
 ## Configuration
 
@@ -48,3 +53,10 @@ plugins:
 
 * The eta_strftime uses built in python functions to format the time, examples can be found [here](https://strftime.org/).  
 * Be careful when using the character `:` in the messages, some firmwares will [expect a checksum and crash](https://community.octoprint.org/t/error-no-checksum-with-line-number-last-line-18/8838/2).  To fix this issues either omit the character or update to the latest version of Marlin.
+
+### Layer progress etc.
+If you chose to install [DisplayLayerProgress](https://plugins.octoprint.org/plugins/DisplayLayerProgress), enable one or all of:
+
+* Layer {layerProgress} 
+* Height {heightProgress}
+* Fil. change {changeFilamentIn}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Install manually using this URL:
 If you also want to display layer progress, height progress or time to filament change, you will have to install the plugin [DisplayLayerProgress](https://plugins.octoprint.org/plugins/DisplayLayerProgress).
 Follow setup instructions for that plugin.
 
+You will probably want to disable 'Printer Display' in the settings for DisplayLayerProgress.
+
 ## Configuration
 
 ### Manual Config File

--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -190,14 +190,13 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 				'ETL {printTimeLeft}',
 				'ETA {ETA}',
 				'{accuracy} accuracy', 
-				'Layer {layerProgress]'
+				'Layer {layerProgress}'
 			],
 			messages=[
 				'{completion:.2f}% complete',
 				'ETL {printTimeLeft}',
 				'ETA {ETA}',
-				'{accuracy} accuracy', 
-				'Layer {layerProgress]'
+				'{accuracy} accuracy'
 			]
 		)
 

--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -23,9 +23,6 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 	_messages = []
 	_M73 = False
 	_PrusaStyle = False
-	_layerIs = "N/A"
-	_heightIs = "N/A"
-	_changeFilamentSeconds = "N/A"
 	
 	def on_event(self, event, payload):
 		if event == Events.PRINT_STARTED:
@@ -72,7 +69,7 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 			# we have nothing to do here
 			return
 		try:
-			currentData = self._printer.get_current_data()			
+			currentData = self._printer.get_current_data()
 			currentData = self._sanitize_current_data(currentData)
 
 			message = self._get_next_message(currentData)
@@ -104,6 +101,10 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 
 		currentData["progress"]["printTimeLeftString"] = "No ETL yet"
 		currentData["progress"]["ETA"] = "No ETA yet"
+		currentData["progress"]["layerProgress"] = "N/A"
+		currentData["progress"]["heightProgress"] = "N/A"
+		currentData["progress"]["changeFilamentIn"] = "N/A"
+		
 		accuracy = currentData["progress"]["printTimeLeftOrigin"]
 		if accuracy:
 			if accuracy == "estimate":
@@ -120,6 +121,7 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 		else:
 			accuracy = "N/A"
 		currentData["progress"]["accuracy"] = accuracy
+		
 		currentData["progress"]["filename"] = currentData["job"]["file"]["name"]
 
 		# Add additional data
@@ -132,7 +134,8 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 				time.time() + currentData["progress"]["printTimeLeft"]))
 			currentData["progress"]["layerProgress"] = self._layerIs
 			currentData["progress"]["heightProgress"] = self._heightIs
-			currentData["progress"]["changeFilamentIn"] = self._get_time_from_seconds(self._changeFilamentSeconds)
+			currentData["progress"]["changeFilamentIn"] = self._get_time_from_seconds(
+				self._changeFilamentSeconds)
 		except Exception as e:
 			self._logger.debug(
 				"Caught an exception trying to parse data: {0}\n Error is: {1}\nTraceback:{2}".format(currentData, e,

--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -24,7 +24,9 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 	_M73 = False
 	_PrusaStyle = False
 	_layerIs = "N/A"
-
+	_heightIs = "N/A"
+	_changeFilamentSeconds = "N/A"
+	
 	def on_event(self, event, payload):
 		if event == Events.PRINT_STARTED:
 			self._logger.info("Printing started. Detailed progress started.")
@@ -62,7 +64,9 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 			
 		elif event.startswith('DisplayLayerProgress'):			
 			self._layerIs = "{0}/{1}".format(payload['currentLayer'], payload['totalLayer'])
-
+			self._heightIs = "{0}/{1}".format(payload['currentHeightFormatted'], payload['totalHeightFormatted'])
+			self._changeFilamentSeconds = "{0}".format(payload['changeFilamentTimeLeftInSeconds'])
+			
 	def do_work(self):
 		if not self._printer.is_printing():
 			# we have nothing to do here
@@ -127,6 +131,8 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 			currentData["progress"]["ETA"] = time.strftime(self._eta_strftime, time.localtime(
 				time.time() + currentData["progress"]["printTimeLeft"]))
 			currentData["progress"]["layerProgress"] = self._layerIs
+			currentData["progress"]["heightProgress"] = self._heightIs
+			currentData["progress"]["changeFilamentIn"] = self._get_time_from_seconds(self._changeFilamentSeconds)
 		except Exception as e:
 			self._logger.debug(
 				"Caught an exception trying to parse data: {0}\n Error is: {1}\nTraceback:{2}".format(currentData, e,
@@ -147,7 +153,9 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 			filepos=currentData["progress"]["filepos"],
 			accuracy=currentData["progress"]["accuracy"],
 			filename=currentData["progress"]["filename"],
-			layerProgress=currentData["progress"]["layerProgress"]
+			layerProgress=currentData["progress"]["layerProgress"], 
+			heightProgress=currentData["progress"]["heightProgress"],
+			changeFilamentIn = currentData["progress"]["changeFilamentIn"]
 		)
 
 	def _get_time_from_seconds(self, seconds):
@@ -186,11 +194,13 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 			M73_PrusaStyle=False,
 			all_messages=[
 				'{filename}',
-				'{completion:.2f}% complete',
-				'ETL {printTimeLeft}',
-				'ETA {ETA}',
+				'{completion:.2f}% complete', 
+				'ETL {printTimeLeft}', 
+				'ETA {ETA}', 
 				'{accuracy} accuracy', 
-				'Layer {layerProgress}'
+				'Layer {layerProgress}', 
+				'Height {heightProgress}', 
+				'Change filament in {changeFilamentIn}'
 			],
 			messages=[
 				'{completion:.2f}% complete',

--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -207,7 +207,7 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 				'{accuracy} accuracy', 
 				'Layer {layerProgress}', 
 				'Height {heightProgress}', 
-				'Change filament in {changeFilamentIn}'
+				'Fil. change {changeFilamentIn}'
 			],
 			messages=[
 				'{completion:.2f}% complete',

--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -62,7 +62,7 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 		elif event.startswith('DisplayLayerProgress'):			
 			self._layerIs = "{0}/{1}".format(payload['currentLayer'], payload['totalLayer'])
 			self._heightIs = "{0}/{1}".format(payload['currentHeightFormatted'], payload['totalHeightFormatted'])
-			self._changeFilamentSeconds = "{0}".format(payload['changeFilamentTimeLeftInSeconds'])
+			self._changeFilamentSeconds = payload['changeFilamentTimeLeftInSeconds']
 			
 	def do_work(self):
 		if not self._printer.is_printing():
@@ -134,8 +134,12 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 				time.time() + currentData["progress"]["printTimeLeft"]))
 			currentData["progress"]["layerProgress"] = self._layerIs
 			currentData["progress"]["heightProgress"] = self._heightIs
-			currentData["progress"]["changeFilamentIn"] = self._get_time_from_seconds(
-				self._changeFilamentSeconds)
+			if isinstance(self._changeFilamentSeconds, int):
+				if self._changeFilamentSeconds == 0:
+					currentData["progress"]["changeFilamentIn"] = "N/A"
+				else: 
+					currentData["progress"]["changeFilamentIn"] = self._get_time_from_seconds(
+						self._changeFilamentSeconds)
 		except Exception as e:
 			self._logger.debug(
 				"Caught an exception trying to parse data: {0}\n Error is: {1}\nTraceback:{2}".format(currentData, e,

--- a/octoprint_detailedprogress/templates/detailedprogress_settings.jinja2
+++ b/octoprint_detailedprogress/templates/detailedprogress_settings.jinja2
@@ -8,6 +8,7 @@
         <li>Set desired formats for variables</li>
         <li>Save settings</li>
     </ol>
+    <p>To display layer progress, height progress or time to filamentchange you will have to install <a target="_new" href="https://plugins.octoprint.org/plugins/DisplayLayerProgress/">DisplayLayerProgress</a>.</p>
     <i class="icon-warning-sign"></i>&nbsp;&nbsp;<h5 style="display: inline-block">Warning</h5>
     <p>Changing settings without understanding what you are doing can cause prints to fail!</p>
     <ul>


### PR DESCRIPTION
OK

So I've added support for showing layer progress on this great plugin.
First time for me developing for OctoPrint (and making a pull request), so I have no idea if I have followed standards. I've tried to do my best. :-)

Anyway, this change makes use of another plugin, [https://github.com/OllisGit/OctoPrint-DisplayLayerProgress]().
That pushes out events, which I grab in 'on_event', and extracts two keys, 'currentLayer' and 'totalLayer' from the payload.
They are then inserted in _layerProgress' and added to 'currentData' in '_sanitize_current_data'.
The layerProgress is added to 'message' in _get_next_message', and is eventually added to 'all_messages' in 'get_settings_default'.

Here it is so far anyway, and it's working for me.

/jon