### PR TITLE
Allow user to enable M73 R output #36

### DIFF
--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -22,7 +22,7 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 	_all_messages = []
 	_messages = []
 	_M73 = False
-	_PrusaStyle = False
+	_M73_R = False
 	
 	def on_event(self, event, payload):
 		if event == Events.PRINT_STARTED:
@@ -32,7 +32,7 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 			self._all_messages = self._settings.get(["all_messages"])
 			self._messages = self._settings.get(["messages"])
 			self._M73 = self._settings.get(["use_M73"])
-			self._PrusaStyle = self._settings.get(["M73_PrusaStyle"])
+			self._M73_R = self._settings.get(["use_M73_R"])
 			self._repeat_timer = octoprint.util.RepeatedTimer(self._settings.get_int(["time_to_change"]), self.do_work)
 			self._repeat_timer.start()
 		elif event in (Events.PRINT_DONE, Events.PRINT_FAILED, Events.PRINT_CANCELLED):
@@ -84,10 +84,9 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 
 	def _update_progress(self, currentData):
 		progressPerc = int(currentData["progress"]["completion"])
-		if self._PrusaStyle:
+		if self._M73_R:
 			printMinutesLeft = int(currentData["progress"]["printTimeLeft"] / 60)
 			self._printer.commands("M73 P{} R{}".format(progressPerc, printMinutesLeft))
-			self._printer.commands("M73 Q{} S{}".format(progressPerc, printMinutesLeft))
 		else:
 			self._printer.commands("M73 P{}".format(progressPerc))
 
@@ -198,8 +197,8 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 			etl_format="{hours:02d}h{minutes:02d}m{seconds:02d}s",
 			print_done_message="Print Done",
 			use_M73=True,
-                        show_ip_at_startup=True,
-			M73_PrusaStyle=False,
+			use_M73_R=False,
+			show_ip_at_startup=True,
 			all_messages=[
 				'{filename}',
 				'{completion:.2f}% complete', 

--- a/octoprint_detailedprogress/static/js/DetailedProgress.js
+++ b/octoprint_detailedprogress/static/js/DetailedProgress.js
@@ -16,6 +16,7 @@ $(function() {
     self.etl_format = ko.observable();
     self.print_done_message = ko.observable();
     self.use_M73 = ko.observable();
+    self.use_M73_R = ko.observable();
     self.show_ip_at_startup = ko.observable();
     self.all_messages = ko.observableArray();
     self.messages = ko.observableArray();
@@ -25,6 +26,7 @@ $(function() {
       self.eta_strftime(self.settings.settings.plugins.detailedprogress.eta_strftime());
       self.etl_format(self.settings.settings.plugins.detailedprogress.etl_format());
       self.use_M73(self.settings.settings.plugins.detailedprogress.use_M73());
+      self.use_M73_R(self.settings.settings.plugins.detailedprogress.use_M73_R());
       self.show_ip_at_startup(self.settings.settings.plugins.detailedprogress.show_ip_at_startup());
       self.print_done_message(self.settings.settings.plugins.detailedprogress.print_done_message());
       self.messages(self.settings.settings.plugins.detailedprogress.messages());
@@ -36,6 +38,7 @@ $(function() {
       self.eta_strftime = self.settings.settings.plugins.detailedprogress.eta_strftime();
       self.etl_format = self.settings.settings.plugins.detailedprogress.etl_format();
       self.use_M73 = self.settings.settings.plugins.detailedprogress.use_M73();
+      self.use_M73_R = self.settings.settings.plugins.detailedprogress.use_M73_R();
       self.show_ip_at_startup = self.settings.settings.plugins.detailedprogress.show_ip_at_startup();
       self.print_done_message = self.settings.settings.plugins.detailedprogress.print_done_message();
       self.messages = self.settings.settings.plugins.detailedprogress.messages();

--- a/octoprint_detailedprogress/templates/detailedprogress_settings.jinja2
+++ b/octoprint_detailedprogress/templates/detailedprogress_settings.jinja2
@@ -70,19 +70,33 @@
 		</div>
 	</div>
   
-  <h4>Progress bar update<h4>
+  <h4>Progress bar update</h4>
 	
-  <div class="control-group">
-		<label class="control-label">{{ _('Send M73 Progress Updates') }}</label>
+    <div class="control-group">
 		<div class="controls">
-      <input type="checkbox" class="input-block-level form-check-input" data-bind="checked: settings.plugins.detailedprogress.use_M73">
+			<label class="checkbox">
+				<input type="checkbox" data-bind="checked: settings.plugins.detailedprogress.use_M73">
+				{{ _('Send M73 Progress Updates') }}
+			</label>
+		</div>
+	</div>
+	
+	<div class="control-group">
+		<div class="controls">
+			<label class="checkbox">
+				&nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" data-bind="checked: settings.plugins.detailedprogress.use_M73_R, enable: settings.plugins.detailedprogress.use_M73">
+				{{ _('Emit remaining time in M73') }}
+			</label>
+			<span class="help-block">Requires Marlin LCD_SET_PROGRESS_MANUALLY option - also supported in Prusa.</span>
 		</div>
 	</div>
 
-  <div class="control-group">
-		<label class="control-label">{{ _('Show Ip at Startup') }}</label>
+    <div class="control-group">
 		<div class="controls">
-      <input type="checkbox" class="input-block-level form-check-input" data-bind="checked: settings.plugins.detailedprogress.show_ip_at_startup">
+			<label class="checkbox">
+				<input type="checkbox" data-bind="checked: settings.plugins.detailedprogress.show_ip_at_startup">
+				{{ _('Show Ip at Startup') }}
+			</label>
 		</div>
 	</div>
 


### PR DESCRIPTION
Like we discussed 👍 

- Remove Prusa support which wasn't available anyway.
- Clean up the front-end checkbox layout according to what the rest of OctoPrint uses.

