### PR TITLE
Avoid exception during print start

### DIFF
--- a/octoprint_detailedprogress/__init__.py
+++ b/octoprint_detailedprogress/__init__.py
@@ -85,8 +85,11 @@ class DetailedProgress(octoprint.plugin.EventHandlerPlugin,
 	def _update_progress(self, currentData):
 		progressPerc = int(currentData["progress"]["completion"])
 		if self._M73_R:
-			printMinutesLeft = int(currentData["progress"]["printTimeLeft"] / 60)
-			self._printer.commands("M73 P{} R{}".format(progressPerc, printMinutesLeft))
+			try:
+				printMinutesLeft = int(currentData["progress"]["printTimeLeft"] / 60)
+				self._printer.commands("M73 P{} R{}".format(progressPerc, printMinutesLeft))
+			except TypeError:
+				self._printer.commands("M73 P{}".format(progressPerc))
 		else:
 			self._printer.commands("M73 P{}".format(progressPerc))
 


### PR DESCRIPTION
At the beginning of the print, I'm seeing the following errors:

```
2024-07-14 17:22:12,139 - octoprint.plugins.detailedprogress - INFO - Message: ETA: No ETA yet
2024-07-14 17:22:12,141 - octoprint.plugins.detailedprogress - INFO - Caught an exception unsupported operand type(s) for /: 'NoneType' and 'int'
Traceback:Traceback (most recent call last):
  File "/home/pi/oprint/lib/python3.9/site-packages/octoprint_detailedprogress/__init__.py", line 80, in do_work
    self._update_progress(currentData)
  File "/home/pi/oprint/lib/python3.9/site-packages/octoprint_detailedprogress/__init__.py", line 88, in _update_progress
    printMinutesLeft = int(currentData["progress"]["printTimeLeft"] / 60)
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'

2024-07-14 17:22:22,144 - octoprint.plugins.detailedprogress - INFO - Message: 0.31% complete
2024-07-14 17:22:22,147 - octoprint.plugins.detailedprogress - INFO - Caught an exception unsupported operand type(s) for /: 'NoneType' and 'int'
Traceback:Traceback (most recent call last):
  File "/home/pi/oprint/lib/python3.9/site-packages/octoprint_detailedprogress/__init__.py", line 80, in do_work
    self._update_progress(currentData)
  File "/home/pi/oprint/lib/python3.9/site-packages/octoprint_detailedprogress/__init__.py", line 88, in _update_progress
    printMinutesLeft = int(currentData["progress"]["printTimeLeft"] / 60)
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```

This commit should avoid them.